### PR TITLE
Ergänze eidesstattliche versicherung.mdx

### DIFF
--- a/src/content/pages/forms/de.mdx
+++ b/src/content/pages/forms/de.mdx
@@ -40,3 +40,9 @@ Dieser Folgeantrag sollte nur genutzt werden, wenn es keine Anwältin oder Berat
 <ExternalShortLink identifier="form_detention"/>
 
 Betroffene von Abschiebehaft können eine sogenannte Person des Vertrauens zusätzlich oder anstatt einer Anwältin benennen. Die Person des Vertrauens unterstützt die Person, die im Abschiebegefängnis selbst oft wenig regeln kann. Sie kann auch Beschwerden gegen die Haft für die Betroffenen einreichen und Akteneinsicht nehmen. Die Abschiebehaftkontaktgruppe in Dresden berät ehrenamtlich in der Abschiebehaft und unterstützt gerne dabei.
+
+## Eidesstattliche Versicherung ##
+
+<ExternalShortLink identifier="form_affirmation"/>
+
+Eine Eidesstattliche Versicherung ist so ähnlich wie eine schriftliche Zeugenaussage, bei der man schwört, die Wahrheit zu sagen. Man kann es als Beweis gegenüber Behörden benutzen. Wenn man dabei lügt, droht eine Geldstrafe oder sogar Gefängnis. 


### PR DESCRIPTION
Eine Eidesstattliche Versicherung ist so ähnlich wie eine schriftliche Zeugenaussage, bei der man schwört, die Wahrheit zu sagen. Man kann es als Beweis gegenüber Behörden benutzen. Wenn man dabei lügt, droht eine Geldstrafe oder sogar Gefängnis.