### PR TITLE
neuer link deportationalarm.yml

### DIFF
--- a/src/content/addresses/deportationalarm.yml
+++ b/src/content/addresses/deportationalarm.yml
@@ -1,6 +1,6 @@
 identifier: deportationalarm
 name: Deportation Alarm
-url: https://noborderassembly.blackblogs.org/deportation-alarm/
+url: https://de.deportationwatch.net/en
 lastChecked: 2025-03-15
 telegram: deportation_alarm
 instagram: deport_alarm


### PR DESCRIPTION
falls ihr euch auch fragt, wo die Seite von deportation alarm hin ist bzw. ihr euch den Link auf die neue Seite nicht gespeichert hat: der Server bei blackblogs.org ist offline, die neue Seite findet ihr hier: https://de.deportationwatch.net/en

Die Seite sieht anders aus, bietet aber die gleichen Infos und neue zu Abschiebungshaft u.a. bundesweit.