### PR TITLE
referenz zu psychT auf psycht angepasst

### DIFF
--- a/src/content/pages/contacts/ar.mdx
+++ b/src/content/pages/contacts/ar.mdx
@@ -97,7 +97,7 @@ lastChecked: 2026-02-03
 هنا يمكنكم البحث عن معالجين نفسيين يتحدثون لغات مختلفة
 :
 
-<ExternalShortLink identifier="psychT" />
+<ExternalShortLink identifier="psycht" />
 
 ### هيئات رصد عمليات الترحيل
 

--- a/src/content/pages/contacts/de.mdx
+++ b/src/content/pages/contacts/de.mdx
@@ -94,7 +94,7 @@ Es gibt Beratungsstellen in Chemnitz, Dresden und Leipzig:
 
 Hier können Sie Psychotherapeut\*innen suchen, die verschiedene Sprachen sprechen können:
 
-<ExternalShortLink identifier="psychT" />
+<ExternalShortLink identifier="psycht" />
 
 ### Abschiebebeobachtungsstellen
 

--- a/src/content/pages/contacts/en.mdx
+++ b/src/content/pages/contacts/en.mdx
@@ -89,7 +89,7 @@ There are counselling centres in Chemnitz, Dresden and Leipzig:
 
 Here you can search for psychotherapists who speak different languages:
 
-<ExternalShortLink identifier="psychT" />
+<ExternalShortLink identifier="psycht" />
 
 ### Deportation monitoring centres ("Abschiebebeobachtungsstellen")
 

--- a/src/content/pages/contacts/es.mdx
+++ b/src/content/pages/contacts/es.mdx
@@ -90,7 +90,7 @@ Existen centros de asesoramiento en Chemnitz, Dresde y Leipzig:
 
 Aquí puedes buscar psicoterapeutas que hablen diferentes idiomas:
 
-<ExternalShortLink identifier="psychT" />
+<ExternalShortLink identifier="psycht" />
 
 ### Observatorios de deportación
 

--- a/src/content/pages/contacts/fr.mdx
+++ b/src/content/pages/contacts/fr.mdx
@@ -89,7 +89,7 @@ Il existe des centres de consultation à Chemnitz, Dresde et Leipzig :
 
 Tu peux chercher ici des psychothérapeutes qui parlent différentes langues:
 
-<ExternalShortLink identifier="psychT" />
+<ExternalShortLink identifier="psycht" />
 
 ### Centres d'observation des expulsions
 

--- a/src/content/pages/contacts/ku.mdx
+++ b/src/content/pages/contacts/ku.mdx
@@ -91,7 +91,7 @@ Navenda Psîkososyal ya Sachsen navendek taybet e ku alîkariya giyanî ya bo ke
 
 Li vir hûn dikarin li psîkoterapîstên ku bi zimanên cuda diaxivin bigerin:
 
-<ExternalShortLink identifier="psychT" />
+<ExternalShortLink identifier="psycht" />
 
 ### Navendên Çavdêriyê ya li ser Radestkirinê
 


### PR DESCRIPTION
#1055 hatte einen Fehler, sodass der Link zur Suche für Psychotherapeuten nicht angezeigt wurde.

Referenz auf psychT muss zu psycht angepasst werden